### PR TITLE
Refactor URL validation in getMarkdownMD to allow for subdomains of medium.com

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,7 +63,8 @@ export default async function getMarkdownMD(url) {
 
   // will use markdown for error messages
   try {
-    if (new URL(url).hostname !== "medium.com") {
+    const hostname = new URL(url).hostname;
+    if (!hostname.includes("medium.com")) {
       return { error: true, markdown: "Invalid URL: Please use a medium.com URL." }
     }
     const response = await fetch(url, {


### PR DESCRIPTION
Allow the tool to be used with medium profile subdomains.
ex: profile.medium.com